### PR TITLE
fix: resolve compilation errors in variadic macros SI2_ERR and SI2_LOG

### DIFF
--- a/src/sound/SI2.hpp
+++ b/src/sound/SI2.hpp
@@ -9,8 +9,8 @@
 #include <fmod_errors.h>
 
 
-#define SI2_ERR(errcode, format, ...) SI2::Log_Write(__LINE__, __FILE__, errcode, format, __VA_ARGS__)
-#define SI2_LOG(format, ...) SI2::Log_Write(__LINE__, __FILE__, FMOD_OK, format, __VA_ARGS__)
+#define SI2_ERR(errcode, format, ...) SI2::Log_Write(__LINE__, __FILE__, errcode, format, ##__VA_ARGS__)
+#define SI2_LOG(format, ...) SI2::Log_Write(__LINE__, __FILE__, FMOD_OK, format, ##__VA_ARGS__)
 
 class SI2 {
     public:


### PR DESCRIPTION
This fix is needed in order to build on most compilers, as empty variadic macros are only allowed as part of an extension before C++20 (GNUCPP).